### PR TITLE
Add immersive one-page website

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Harmoniq AI</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header class="main-header">
+        <div class="logo">Harmoniq AI</div>
+        <nav class="main-nav">
+            <ul>
+                <li><a href="#hero">Accueil</a></li>
+                <li><a href="#services">Services</a></li>
+                <li><a href="#offers">Offres</a></li>
+                <li><a href="#about">À propos</a></li>
+                <li><a href="#approach">Approche</a></li>
+                <li><a href="#contact">Contact</a></li>
+                <li><a href="#roi">Calculateur ROI</a></li>
+                <li><a href="#needs">Évaluer mes besoins</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <section id="hero" class="hero">
+        <div class="hero-content">
+            <h1>Automatisez, Respirez, Travaillez en toute sérénité</h1>
+            <p>Harmoniq AI transforme votre quotidien professionnel grâce à des solutions d’automatisation zen et humaines.</p>
+            <a href="https://calendly.com" class="btn primary-btn">Prendre rendez-vous</a>
+        </div>
+    </section>
+
+    <section id="services" class="services">
+        <h2>Nos services</h2>
+        <div class="services-grid">
+            <div class="service" data-service="email">Automatisation des emails</div>
+            <div class="service" data-service="calendar">Gestion de calendrier</div>
+            <div class="service" data-service="data">Traitement des données</div>
+            <div class="service" data-service="workflows">Workflows intelligents</div>
+            <div class="service" data-service="support">Service client IA</div>
+            <div class="service" data-service="content">Création de contenu</div>
+            <div class="service" data-service="hr">Gestion RH</div>
+            <div class="service" data-service="quote">Création de devis</div>
+        </div>
+
+        <div id="service-popups">
+            <div class="popup" data-service="email">
+                <h3>Automatisation des emails</h3>
+                <ul>
+                    <li>Envoi automatique des réponses</li>
+                    <li>Segmentation intelligente</li>
+                    <li>Suivi des campagnes</li>
+                </ul>
+            </div>
+            <div class="popup" data-service="calendar">
+                <h3>Gestion de calendrier</h3>
+                <ul>
+                    <li>Prise de rendez-vous simplifiée</li>
+                    <li>Rappels automatiques</li>
+                    <li>Synchronisation multi-appareils</li>
+                </ul>
+            </div>
+            <div class="popup" data-service="data">
+                <h3>Traitement des données</h3>
+                <ul>
+                    <li>Collecte et nettoyage</li>
+                    <li>Analyse automatisée</li>
+                    <li>Reporting clair</li>
+                </ul>
+            </div>
+            <div class="popup" data-service="workflows">
+                <h3>Workflows intelligents</h3>
+                <ul>
+                    <li>Processus sur mesure</li>
+                    <li>Suivi en temps réel</li>
+                    <li>Intégration simplifiée</li>
+                </ul>
+            </div>
+            <div class="popup" data-service="support">
+                <h3>Service client IA</h3>
+                <ul>
+                    <li>Chatbots bienveillants</li>
+                    <li>Disponibilité 24/7</li>
+                    <li>Analyses de satisfaction</li>
+                </ul>
+            </div>
+            <div class="popup" data-service="content">
+                <h3>Création de contenu</h3>
+                <ul>
+                    <li>Rédaction assistée par IA</li>
+                    <li>Optimisation SEO</li>
+                    <li>Calendrier éditorial</li>
+                </ul>
+            </div>
+            <div class="popup" data-service="hr">
+                <h3>Gestion RH</h3>
+                <ul>
+                    <li>Suivi des absences</li>
+                    <li>Onboarding automatisé</li>
+                    <li>Gestion des talents</li>
+                </ul>
+            </div>
+            <div class="popup" data-service="quote">
+                <h3>Création de devis</h3>
+                <ul>
+                    <li>Génération rapide</li>
+                    <li>Personnalisation facile</li>
+                    <li>Suivi des signatures</li>
+                </ul>
+            </div>
+        </div>
+    </section>
+
+    <section id="about" class="philosophy">
+        <h2>Notre philosophie</h2>
+        <p>Chez Harmoniq AI, nous croyons que la technologie doit être au service de l'humain. Notre approche zen vise à créer un environnement de travail plus serein, où chacun peut se concentrer sur l’essentiel.</p>
+    </section>
+
+    <section id="offers" class="offers">
+        <h2>Nos offres</h2>
+        <div class="offer-cards">
+            <div class="offer">
+                <h3>Zen</h3>
+                <p>1–2 automatisations essentielles</p>
+                <p class="price">297€ / mois</p>
+            </div>
+            <div class="offer">
+                <h3>Sérénité</h3>
+                <p>4–5 automatisations + dashboard + suivi</p>
+                <p class="price">997€ / mois</p>
+            </div>
+            <div class="offer">
+                <h3>Harmonie</h3>
+                <p>Sur-mesure + illimité + API</p>
+                <p class="price">2 997€ / mois</p>
+            </div>
+        </div>
+    </section>
+
+    <section id="roi" class="roi">
+        <h2>Simulateur de ROI</h2>
+        <form id="roi-form">
+            <label>Services à automatiser</label>
+            <input type="text" id="roi-services" placeholder="ex: emails, calendrier">
+            <label>Heures gagnées par semaine</label>
+            <input type="number" id="roi-hours" placeholder="10">
+            <label>Coût horaire moyen (€)</label>
+            <input type="number" id="roi-rate" placeholder="40">
+            <label>Personnes concernées</label>
+            <input type="number" id="roi-people" placeholder="3">
+            <button type="submit" class="btn secondary-btn">Calculer</button>
+        </form>
+        <div id="roi-result"></div>
+    </section>
+
+    <section id="needs" class="needs">
+        <h2>Analyse de vos besoins</h2>
+        <form id="needs-form">
+            <label>Secteur</label>
+            <input type="text" id="need-sector">
+            <label>Nombre de tâches répétitives</label>
+            <input type="number" id="need-tasks">
+            <label>Budget mensuel</label>
+            <input type="number" id="need-budget">
+            <label>Objectif principal</label>
+            <input type="text" id="need-goal">
+            <label>Besoins spécifiques</label>
+            <textarea id="need-details"></textarea>
+            <button type="submit" class="btn secondary-btn">Analyser</button>
+        </form>
+        <div id="needs-result"></div>
+    </section>
+
+    <section id="partners" class="partners">
+        <div class="partner-track">
+            <div class="partner-logo">Notion</div>
+            <div class="partner-logo">Make</div>
+            <div class="partner-logo">Zapier</div>
+            <div class="partner-logo">Airtable</div>
+            <div class="partner-logo">OpenAI</div>
+            <div class="partner-logo">Softr</div>
+            <div class="partner-logo">n8n</div>
+            <div class="partner-logo">Calendly</div>
+        </div>
+    </section>
+
+    <footer id="contact" class="footer">
+        <p>Contact : <a href="mailto:contact@harmoniq.ai">contact@harmoniq.ai</a></p>
+        <p><a href="https://calendly.com">Prendre rendez-vous</a></p>
+    </footer>
+
+    <div id="overlay"></div>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,52 @@
+// popup services
+const services = document.querySelectorAll('.service');
+const popups = document.querySelectorAll('.popup');
+const overlay = document.getElementById('overlay');
+
+services.forEach(service => {
+    service.addEventListener('click', () => {
+        const key = service.dataset.service;
+        const popup = document.querySelector(`.popup[data-service="${key}"]`);
+        if (popup) {
+            popup.style.display = 'block';
+            overlay.style.display = 'block';
+        }
+    });
+});
+
+overlay.addEventListener('click', () => {
+    popups.forEach(p => p.style.display = 'none');
+    overlay.style.display = 'none';
+});
+
+// ROI calculator
+const roiForm = document.getElementById('roi-form');
+const roiResult = document.getElementById('roi-result');
+
+roiForm.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const hours = parseFloat(document.getElementById('roi-hours').value) || 0;
+    const rate = parseFloat(document.getElementById('roi-rate').value) || 0;
+    const people = parseInt(document.getElementById('roi-people').value) || 1;
+    const monthly = hours * rate * people * 4;
+    const yearly = monthly * 12;
+    let pack = 'Zen';
+    if (monthly > 2000) pack = 'Harmonie';
+    else if (monthly > 800) pack = 'Sérénité';
+    roiResult.textContent = `Économie potentielle : ${yearly.toFixed(0)}€ par an. Pack recommandé : ${pack}`;
+});
+
+// needs analyzer
+const needsForm = document.getElementById('needs-form');
+const needsResult = document.getElementById('needs-result');
+
+needsForm.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const tasks = parseInt(document.getElementById('need-tasks').value) || 0;
+    const budget = parseFloat(document.getElementById('need-budget').value) || 0;
+    let pack = 'Zen';
+    if (tasks > 5 && budget >= 1000) pack = 'Harmonie';
+    else if (tasks > 2 && budget >= 500) pack = 'Sérénité';
+    const sector = document.getElementById('need-sector').value;
+    needsResult.textContent = `Secteur: ${sector}. Pack conseillé: ${pack}.`; 
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,232 @@
+:root {
+    --lavender: #e6e6fa;
+    --violet: #d9c8ff;
+    --white-glass: rgba(255, 255, 255, 0.3);
+    --gradient-start: #e6e6fa;
+    --gradient-end: #d0e0ff;
+    --text: #333;
+    --shadow: rgba(0, 0, 0, 0.1);
+}
+
+html, body {
+    margin: 0;
+    padding: 0;
+    font-family: 'Poppins', sans-serif;
+    color: var(--text);
+    background: linear-gradient(180deg, var(--gradient-start), var(--gradient-end));
+    scroll-behavior: smooth;
+}
+
+.main-header {
+    position: fixed;
+    top: 0;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 2rem;
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(10px);
+    box-shadow: 0 4px 30px var(--shadow);
+    z-index: 1000;
+}
+
+.main-nav ul {
+    list-style: none;
+    display: flex;
+    gap: 1rem;
+    margin: 0;
+    padding: 0;
+}
+
+.main-nav a {
+    color: var(--text);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.hero {
+    height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    background: url('https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=1500&q=80') center/cover no-repeat;
+    color: #fff;
+    position: relative;
+}
+
+.hero::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(0,0,0,0.3);
+    backdrop-filter: blur(2px);
+}
+
+.hero-content {
+    position: relative;
+    z-index: 1;
+    max-width: 800px;
+}
+
+.btn {
+    display: inline-block;
+    padding: 0.75rem 1.5rem;
+    border-radius: 30px;
+    text-decoration: none;
+    font-weight: 600;
+    margin-top: 1rem;
+}
+
+.primary-btn {
+    color: #fff;
+    background: linear-gradient(90deg, var(--lavender), var(--violet));
+}
+
+.secondary-btn {
+    background: var(--white-glass);
+    color: var(--text);
+}
+
+.services {
+    padding: 6rem 2rem;
+    text-align: center;
+}
+
+.services-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+    margin-top: 2rem;
+}
+
+.service {
+    background: var(--white-glass);
+    padding: 1rem;
+    border-radius: 20px;
+    cursor: pointer;
+    backdrop-filter: blur(10px);
+    box-shadow: 0 4px 20px var(--shadow);
+    transition: transform 0.2s ease;
+}
+
+.service:hover {
+    transform: translateY(-5px);
+}
+
+.popup {
+    display: none;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: var(--white-glass);
+    backdrop-filter: blur(15px);
+    padding: 2rem;
+    border-radius: 20px;
+    box-shadow: 0 4px 40px var(--shadow);
+    z-index: 1100;
+    width: 90%;
+    max-width: 400px;
+}
+
+#overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.4);
+    z-index: 1050;
+}
+
+.philosophy {
+    padding: 4rem 2rem;
+    text-align: center;
+    background: var(--white-glass);
+    backdrop-filter: blur(8px);
+    margin: 4rem 0;
+    box-shadow: 0 4px 20px var(--shadow);
+}
+
+.offers {
+    padding: 4rem 2rem;
+    text-align: center;
+}
+
+.offer-cards {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: center;
+    margin-top: 2rem;
+}
+
+.offer {
+    background: var(--white-glass);
+    padding: 1.5rem;
+    border-radius: 20px;
+    width: 250px;
+    backdrop-filter: blur(10px);
+    box-shadow: 0 4px 30px var(--shadow);
+}
+
+.price {
+    font-size: 1.2rem;
+    font-weight: 700;
+}
+
+.roi, .needs {
+    padding: 4rem 2rem;
+    text-align: center;
+}
+
+.roi form, .needs form {
+    display: grid;
+    gap: 0.5rem;
+    max-width: 400px;
+    margin: 0 auto;
+    background: var(--white-glass);
+    padding: 1rem;
+    border-radius: 20px;
+    backdrop-filter: blur(10px);
+}
+
+.roi input, .needs input, .needs textarea {
+    padding: 0.5rem;
+    border-radius: 10px;
+    border: none;
+}
+
+#roi-result, #needs-result {
+    margin-top: 1rem;
+    font-weight: 600;
+}
+
+.partners {
+    overflow: hidden;
+    white-space: nowrap;
+    padding: 2rem 0;
+}
+
+.partner-track {
+    display: inline-block;
+    animation: scroll 20s linear infinite;
+}
+
+.partner-logo {
+    display: inline-block;
+    margin: 0 2rem;
+    font-weight: 600;
+    color: var(--text);
+}
+
+@keyframes scroll {
+    0% { transform: translateX(0); }
+    100% { transform: translateX(-50%); }
+}
+
+.footer {
+    text-align: center;
+    padding: 2rem;
+    background: rgba(0,0,0,0.05);
+}


### PR DESCRIPTION
## Summary
- build single-page website for Harmoniq AI with glassmorphism design
- implement header, hero section, services popups, philosophy statement
- add offer cards and ROI calculator
- include needs analysis form, partner logos, and footer
- style with lavender palette and soft animations
- add JS interactivity for popups and calculators

## Testing
- `npm test` *(fails: cannot find package.json)*
- `pytest` *(runs 0 tests)*

------
https://chatgpt.com/codex/tasks/task_e_6849dd5986f083219c26977b2c43f611